### PR TITLE
ci: agrega Jenkinsfile (build + stamp + smoke local) y actualiza README

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,89 @@
+pipeline {
+  agent any
+  options { timestamps() }
+
+  environment {
+    DB_HOST = 'localhost'
+    DB_PORT = '3306'
+    DB_NAME = 'blog'      
+    DB_USER = 'root'      
+    DB_PASS = 'root'    
+    APP_PROFILE = ''
+  }
+
+  stages {
+    stage('Checkout') {
+      steps {
+        git branch: 'master', url: 'https://github.com/Jorge-Urquiza/blog-back.git'
+      }
+    }
+
+    stage('Build (sin tests)') {
+      steps {
+        // Build “prod-like” sin compilar/ejecutar tests
+        bat '.\\mvnw.cmd -B clean package -Dmaven.test.skip=true'
+      }
+    }
+
+    stage('Stamp & Archive') {
+      steps {
+        script {
+          // 1) Detectar el JAR generado (sin plugins extra)
+          def listOut = bat(returnStdout: true, script: '@echo off\r\ndir /b target\\*.jar').trim()
+          def jarLines = listOut.readLines()
+          if (jarLines == null || jarLines.isEmpty()) {
+            error 'No se encontró ningún JAR en target/*.jar'
+          }
+          env.JAR_PATH = ("target\\" + jarLines[0].trim())
+
+          // 2) Obtener GIT_SHA limpio (última línea)
+          def shaOut = bat(returnStdout: true, script: '@echo off\r\ngit rev-parse --short=12 HEAD').trim()
+          def lines = shaOut.readLines()
+          env.GIT_SHA = lines[lines.size() - 1].trim()
+
+          // 3) Nombre final del artefacto
+          env.BUILD_NAME = "blog-back-${env.BUILD_NUMBER}-${env.GIT_SHA}.jar"
+        }
+
+        // 4) Copiar y generar checksum con rutas entre comillas
+        bat """
+          copy /Y "${env.JAR_PATH}" "target\\${env.BUILD_NAME}"
+          certutil -hashfile "target\\${env.BUILD_NAME}" SHA256 > "target\\${env.BUILD_NAME}.sha256.txt"
+        """
+
+        // 5) Publicar artefactos
+        archiveArtifacts artifacts: "target/${env.BUILD_NAME}, target/${env.BUILD_NAME}.sha256.txt", fingerprint: true
+      }
+    }
+
+    stage('Smoke run (MySQL local)') {
+      steps {
+        // Limitamos con timeout y no rompemos el build si expira (queda UNSTABLE).
+        catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+          timeout(time: 40, unit: 'SECONDS') {
+            withEnv([
+              "SPRING_PROFILES_ACTIVE=${APP_PROFILE}",
+              "SPRING_DATASOURCE_URL=jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC",
+              "SPRING_DATASOURCE_USERNAME=${DB_USER}",
+              "SPRING_DATASOURCE_PASSWORD=${DB_PASS}",
+              // Cambia a 'none' si NO quieres que toque el esquema en tu máquina
+              "SPRING_JPA_HIBERNATE_DDL_AUTO=update"
+            ]) {
+              bat """
+                for %%f in (target\\*.jar) do ( set "APP_JAR=%%f" )
+                echo Ejecutando: %APP_JAR%
+                java -jar "%APP_JAR%"
+              """
+            }
+          }
+        }
+      }
+    }
+  }
+
+  post {
+    always {
+      echo "Listo. Artefactos en 'Artifacts'. Si el smoke marcó UNSTABLE es por timeout intencional."
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,83 @@
+# 📌 block-back
+
+API REST para la gestión de un blog básico, que permite la creación de publicaciones (*Posts*) y comentarios.  
+Éste proyecto está desarrollado con **Spring Boot** y utiliza **MySQL** como base de datos.
+
+---
+
+## 🛠️ Tecnologías y Versiones
+
+| Tecnología  | Versión        |
+|-------------|----------------|
+| Java        | 21             |
+| Spring Boot | 3.4.0-SNAPSHOT |
+| MySQL       | Última estable |
+| Maven       | Última estable |
+
+---
+
+## 📋 Requisitos Previos
+
+Antes de ejecutar el proyecto, asegúrate de tener instalado:
+
+- [Java 21](https://www.oracle.com/java/technologies/downloads/#java21) o superior
+- [Maven](https://maven.apache.org/) (versión 3.8+ recomendada)
+- [MySQL](https://dev.mysql.com/downloads/) configurado y en ejecución
+
+---
+
+## 🚀 Ejecución en Local
+
+1. **Clonar el repositorio**
+   ```bash
+   git clone https://github.com/Jorge-Urquiza/blog-back.git
+   cd block-back
+   ```
+
+2. **Configurar base de datos**  
+   Editar el archivo `application.properties` y definir:
+   ```properties
+   spring.datasource.url=jdbc:mysql://localhost:3306/blog
+   spring.datasource.username=<usuario>
+   spring.datasource.password=<contraseña>
+   ```
+
+3. **Compilar y ejecutar**
+   ```bash
+   mvn spring-boot:run
+   ```
+
+---
+
+## 🏗️ Construcción y Empaquetado
+
+Para construir el proyecto y generar el archivo `.jar` ejecuta:
+
+```bash
+mvn clean install
+```
+
+El artefacto generado se encontrará en:
+
+```
+target/block-back-1.0.0.jar
+```
+
+Para ejecutarlo:
+
+```bash
+java -jar target/block-back-1.0.0.jar
+```
+
+---
+
+## 👥 Equipo
+
+| Nombre             |
+|--------------------|
+| Al Ivan Calle      |
+| Jose Andres Mayser |
+| Jorge Urquiza      |
+| Daniel Zeballos    |
+
+---

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>17</java.version>
+		<java.version>21</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,9 +3,13 @@ server.port=3000
 
 logging.level.org.springframework.web.cors=DEBUG
 
-spring.datasource.url=${SPRING_DATASOURCE_URL}
-spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
-spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+spring.datasource.url=jdbc:mysql://localhost:3306/blog
+spring.datasource.username=root
+spring.datasource.password=
+
+#spring.datasource.url=${SPRING_DATASOURCE_URL}
+#spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+#spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
## Resumen
Se incorpora un pipeline de CI para Windows mediante **Jenkinsfile** y se actualiza la documentación (**README**) con:
- Guía de CI en Jenkins (build prod-like sin tests, empaquetado y publicación de artefactos).
- Definición de **“Smoke local”** y por qué puede marcarse **UNSTABLE** con timeout controlado.
- Instrucciones para **ejecutar el `.jar`** post build (Git Bash/CMD/PowerShell), incluyendo flags de conexión a MySQL y puerto.
- Sección de **solución de problemas** (puerto ocupado, credenciales MySQL, wrapper Maven).

## Cambios incluidos
- **Jenkinsfile** en la raíz del repo con las etapas:
  1) *Checkout* de `master`.
  2) *Build (sin tests)*: `mvnw clean package -Dmaven.test.skip=true`.
  3) *Stamp & Archive*: renombra artefacto a `blog-back-<BUILD>-<GITSHA>.jar` y genera `.sha256.txt`.
  4) *Smoke run (MySQL local)*: arranca la app con env vars y `SERVER_PORT=8081` (timeout 40s, `catchError` → `UNSTABLE` esperado si solo verificamos arranque).
- **README**:
  - Nueva sección **CI con Jenkins** (requisitos del agente y cómo conectarlo por *Pipeline from SCM*).
  - Sección **¿Qué es “Smoke local”?**.
  - Sección **Ejecutar el `.jar` después del build** (tres shells).
  - Troubleshooting usual.

## Cómo probar
1. En Jenkins, crear un job **Pipeline → Pipeline script from SCM** apuntando a este repo (branch `master`, `Script Path: Jenkinsfile`).
2. Ejecutar el build y validar:
   - **Artifacts** publicados: `blog-back-<BUILD>-<GITSHA>.jar` y `.sha256.txt`.
   - Stage **Build** en **SUCCESS**.
   - Stage **Smoke run** en **UNSTABLE** (esperado por timeout) *o* en **SUCCESS** si se añadió health-check.
3. Descargar el `.jar` y ejecutar localmente:
   - Asegurar MySQL `localhost:3306` y DB `blog`.
   - Iniciar con:
     ```bash
     java -jar ./blog-back-<BUILD>-<GITSHA>.jar \
       --spring.datasource.url='jdbc:mysql://localhost:3306/blog?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC' \
       --spring.datasource.username=root \
       --spring.datasource.password=root \
       --spring.jpa.hibernate.ddl-auto=update \
       --server.port=8081
     ```
   - Ver “Tomcat started on port(s): 8081”.

## Variables/entorno relevantes (Jenkinsfile)
- `DB_HOST=localhost`, `DB_PORT=3306`, `DB_NAME=blog`, `DB_USER=root`, `DB_PASS=root`
- `SERVER_PORT=8081`
- `SPRING_JPA_HIBERNATE_DDL_AUTO=update` (ajustable)

## Consideraciones
- **Impacto en producción**: nulo, solo CI.
- **Compatibilidad de agente**: pensado para **Windows** (`bat`, `mvnw.cmd`). En Linux habría que adaptar a `sh` y `./mvnw`.
- **Puertos**: si 8081 está en uso, cambiar `SERVER_PORT`.

## Checklist
- [x] Jenkinsfile agregado en raiz.
- [x] README actualizado con CI/Smoke/Ejecución post build.
- [x] Artefactos versionados por `BUILD` + `GITSHA`.
- [x] Saltar tests en CI para rapidez (se pueden reactivar más adelante).
- [ ] (Opcional) Agregar **Actuator** + health-check para cerrar el smoke sin timeout.

## Screenshots / Evidencia (opcional)
- Logs de Jenkins mostrando:
  - `BUILD SUCCESS`
  - Publicación de artifacts
  - Inicio de la app en el smoke (y timeout esperado)

---
**Linked issues:** N/A  
**Labels:** `ci`, `docs`, `windows-agent`
